### PR TITLE
feat: 自前セッション認証をapiに実装 (register/login/logout)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
     "@hono/node-server": "^1.12.0",
     "@hono/zod-openapi": "^0.15.0",
     "@repo/database": "workspace:*",
+    "bcryptjs": "^3.0.3",
     "dotenv": "^16.4.5",
     "hono": "^4.5.1",
     "neverthrow": "^8.1.1",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,8 +1,13 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { cors } from "hono/cors";
+import { loginRouter } from "./feature/auth/login/router";
+import { logoutRouter } from "./feature/auth/logout/router";
+import { registerRouter } from "./feature/auth/register/router";
 import { createNoteRouter } from "./feature/note/create/router";
+import { sessionMiddleware } from "./shared/session-middleware/middleware";
+import type { SessionEnv } from "./shared/session-middleware/types";
 
-export const app = new OpenAPIHono();
+export const app = new OpenAPIHono<SessionEnv>();
 
 app.use(
   "*",
@@ -14,9 +19,24 @@ app.use(
   }),
 );
 
+// 毎リクエストで Cookie を見てセッションを c.var.session に載せる
+app.use("*", sessionMiddleware);
+
 app.get("/health", (c) => c.json({ status: "OK" }));
 
+// 認証
+app.route("/", registerRouter());
+app.route("/", loginRouter());
+app.route("/", logoutRouter());
+
+// ノート
 app.route("/", createNoteRouter());
+
+app.openAPIRegistry.registerComponent("securitySchemes", "sessionCookie", {
+  type: "apiKey",
+  in: "cookie",
+  name: "session_token",
+});
 
 app.doc("/doc", {
   openapi: "3.0.0",

--- a/apps/api/src/feature/auth/login/repository.ts
+++ b/apps/api/src/feature/auth/login/repository.ts
@@ -1,0 +1,55 @@
+import { prisma } from "@repo/database";
+import { ResultAsync } from "neverthrow";
+import type { DbError } from "../../../shared/db-error";
+
+export type LoginUser = {
+  id: string;
+  email: string | null;
+  name: string | null;
+  passwordHash: string | null;
+};
+
+export type CreateSessionData = {
+  sessionToken: string;
+  userId: string;
+  expires: Date;
+};
+
+export interface LoginRepository {
+  findByEmail(email: string): ResultAsync<LoginUser | null, DbError>;
+  createSession(data: CreateSessionData): ResultAsync<void, DbError>;
+}
+
+export class PrismaLoginRepository implements LoginRepository {
+  findByEmail(email: string): ResultAsync<LoginUser | null, DbError> {
+    return ResultAsync.fromPromise(
+      prisma.user.findUnique({
+        where: { email },
+        select: { id: true, email: true, name: true, password: true },
+      }),
+      (cause): DbError => ({ type: "DB_ERROR", cause }),
+    ).map((user) =>
+      user
+        ? {
+            id: user.id,
+            email: user.email,
+            name: user.name,
+            passwordHash: user.password,
+          }
+        : null,
+    );
+  }
+
+  createSession(data: CreateSessionData): ResultAsync<void, DbError> {
+    return ResultAsync.fromPromise(
+      prisma.session.create({
+        data: {
+          sessionToken: data.sessionToken,
+          userId: data.userId,
+          expires: data.expires,
+        },
+      }),
+      (cause): DbError => ({ type: "DB_ERROR", cause }),
+    ).map(() => undefined);
+  }
+}

--- a/apps/api/src/feature/auth/login/router.ts
+++ b/apps/api/src/feature/auth/login/router.ts
@@ -1,0 +1,50 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { setCookie } from "hono/cookie";
+import { match } from "ts-pattern";
+import {
+  SESSION_COOKIE_NAME,
+  SESSION_DURATION_DAYS,
+  type SessionEnv,
+} from "../../../shared/session-middleware/types";
+import { PrismaLoginRepository } from "./repository";
+import { LoginRoute } from "./schema";
+import { LoginUseCase } from "./usecase";
+
+export const loginRouter = () => {
+  const app = new OpenAPIHono<SessionEnv>();
+
+  const usecase = new LoginUseCase(new PrismaLoginRepository());
+
+  app.openapi(LoginRoute, async (c) => {
+    const input = c.req.valid("json");
+
+    const result = await usecase.execute(input);
+
+    return result.match(
+      ({ sessionToken, user }) => {
+        setCookie(c, SESSION_COOKIE_NAME, sessionToken, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === "production",
+          sameSite: "Lax",
+          path: "/",
+          maxAge: SESSION_DURATION_DAYS * 24 * 60 * 60,
+        });
+        return c.json({ id: user.id, email: user.email, name: user.name }, 200);
+      },
+      (error) =>
+        match(error)
+          .with("INVALID_CREDENTIALS", () =>
+            c.json(
+              { error: "メールアドレスまたはパスワードが正しくありません" },
+              401,
+            ),
+          )
+          .with("DB_ERROR", () =>
+            c.json({ error: "ログインに失敗しました" }, 500),
+          )
+          .exhaustive(),
+    );
+  });
+
+  return app;
+};

--- a/apps/api/src/feature/auth/login/schema.ts
+++ b/apps/api/src/feature/auth/login/schema.ts
@@ -1,0 +1,45 @@
+import { createRoute, z } from "@hono/zod-openapi";
+
+export const LoginRequest = z
+  .object({
+    email: z.string().email({ message: "正しいメールアドレスを入力してください" }),
+    password: z.string().min(1, { message: "パスワードは必須です" }),
+  })
+  .openapi("LoginRequest");
+
+export const LoginResponse = z
+  .object({
+    id: z.string(),
+    email: z.string(),
+    name: z.string().nullable(),
+  })
+  .openapi("LoginResponse");
+
+export const LoginErrorResponse = z
+  .object({ error: z.string() })
+  .openapi("LoginErrorResponse");
+
+export const LoginRoute = createRoute({
+  method: "post",
+  path: "/auth/login",
+  description: "ログイン (成功時に session_token クッキーを発行)",
+  request: {
+    body: {
+      content: { "application/json": { schema: LoginRequest } },
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: LoginResponse } },
+      description: "ログイン成功",
+    },
+    401: {
+      content: { "application/json": { schema: LoginErrorResponse } },
+      description: "認証失敗",
+    },
+    500: {
+      content: { "application/json": { schema: LoginErrorResponse } },
+      description: "サーバーエラー",
+    },
+  },
+});

--- a/apps/api/src/feature/auth/login/usecase.ts
+++ b/apps/api/src/feature/auth/login/usecase.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from "node:crypto";
+import bcrypt from "bcryptjs";
+import { err, ok, type Result } from "neverthrow";
+import { SESSION_DURATION_DAYS } from "../../../shared/session-middleware/types";
+import type { LoginRepository } from "./repository";
+
+export type LoginInput = {
+  email: string;
+  password: string;
+};
+
+export type LoginOutput = {
+  sessionToken: string;
+  expiresAt: Date;
+  user: { id: string; email: string; name: string | null };
+};
+
+export type LoginError = "INVALID_CREDENTIALS" | "DB_ERROR";
+
+export class LoginUseCase {
+  constructor(private readonly repo: LoginRepository) {}
+
+  async execute(input: LoginInput): Promise<Result<LoginOutput, LoginError>> {
+    const userResult = await this.repo.findByEmail(input.email);
+    if (userResult.isErr()) return err("DB_ERROR");
+
+    const user = userResult.value;
+    // ユーザー不在 or パスワード未設定は、存在を伏せるため一律 INVALID_CREDENTIALS
+    if (!user || !user.passwordHash) return err("INVALID_CREDENTIALS");
+
+    const valid = await bcrypt.compare(input.password, user.passwordHash);
+    if (!valid) return err("INVALID_CREDENTIALS");
+
+    const sessionToken = randomUUID();
+    const expiresAt = new Date(
+      Date.now() + SESSION_DURATION_DAYS * 24 * 60 * 60 * 1000,
+    );
+
+    const created = await this.repo.createSession({
+      sessionToken,
+      userId: user.id,
+      expires: expiresAt,
+    });
+    if (created.isErr()) return err("DB_ERROR");
+
+    return ok({
+      sessionToken,
+      expiresAt,
+      user: { id: user.id, email: user.email ?? input.email, name: user.name },
+    });
+  }
+}

--- a/apps/api/src/feature/auth/logout/repository.ts
+++ b/apps/api/src/feature/auth/logout/repository.ts
@@ -1,0 +1,17 @@
+import { prisma } from "@repo/database";
+import { ResultAsync } from "neverthrow";
+import type { DbError } from "../../../shared/db-error";
+
+export interface LogoutRepository {
+  deleteByToken(sessionToken: string): ResultAsync<void, DbError>;
+}
+
+export class PrismaLogoutRepository implements LogoutRepository {
+  deleteByToken(sessionToken: string): ResultAsync<void, DbError> {
+    // deleteMany: 該当が無くてもエラーにしない
+    return ResultAsync.fromPromise(
+      prisma.session.deleteMany({ where: { sessionToken } }),
+      (cause): DbError => ({ type: "DB_ERROR", cause }),
+    ).map(() => undefined);
+  }
+}

--- a/apps/api/src/feature/auth/logout/router.ts
+++ b/apps/api/src/feature/auth/logout/router.ts
@@ -1,0 +1,37 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { deleteCookie, getCookie } from "hono/cookie";
+import { match } from "ts-pattern";
+import {
+  SESSION_COOKIE_NAME,
+  type SessionEnv,
+} from "../../../shared/session-middleware/types";
+import { PrismaLogoutRepository } from "./repository";
+import { LogoutRoute } from "./schema";
+import { LogoutUseCase } from "./usecase";
+
+export const logoutRouter = () => {
+  const app = new OpenAPIHono<SessionEnv>();
+
+  const usecase = new LogoutUseCase(new PrismaLogoutRepository());
+
+  app.openapi(LogoutRoute, async (c) => {
+    const token = getCookie(c, SESSION_COOKIE_NAME);
+
+    const result = await usecase.execute(token);
+
+    // 成否に関わらずクッキーは破棄する
+    deleteCookie(c, SESSION_COOKIE_NAME, { path: "/" });
+
+    return result.match(
+      () => c.json({ message: "ログアウトしました" }, 200),
+      (error) =>
+        match(error)
+          .with("DB_ERROR", () =>
+            c.json({ error: "ログアウトに失敗しました" }, 500),
+          )
+          .exhaustive(),
+    );
+  });
+
+  return app;
+};

--- a/apps/api/src/feature/auth/logout/schema.ts
+++ b/apps/api/src/feature/auth/logout/schema.ts
@@ -1,0 +1,25 @@
+import { createRoute, z } from "@hono/zod-openapi";
+
+export const LogoutResponse = z
+  .object({ message: z.string() })
+  .openapi("LogoutResponse");
+
+export const LogoutErrorResponse = z
+  .object({ error: z.string() })
+  .openapi("LogoutErrorResponse");
+
+export const LogoutRoute = createRoute({
+  method: "post",
+  path: "/auth/logout",
+  description: "ログアウト (セッション削除 + クッキー破棄)",
+  responses: {
+    200: {
+      content: { "application/json": { schema: LogoutResponse } },
+      description: "ログアウト成功",
+    },
+    500: {
+      content: { "application/json": { schema: LogoutErrorResponse } },
+      description: "サーバーエラー",
+    },
+  },
+});

--- a/apps/api/src/feature/auth/logout/usecase.ts
+++ b/apps/api/src/feature/auth/logout/usecase.ts
@@ -1,0 +1,20 @@
+import { err, ok, type Result } from "neverthrow";
+import type { LogoutRepository } from "./repository";
+
+export type LogoutError = "DB_ERROR";
+
+export class LogoutUseCase {
+  constructor(private readonly repo: LogoutRepository) {}
+
+  async execute(
+    sessionToken: string | undefined,
+  ): Promise<Result<void, LogoutError>> {
+    // トークンが無い(=既に未ログイン)場合も成功扱い
+    if (!sessionToken) return ok(undefined);
+
+    const deleted = await this.repo.deleteByToken(sessionToken);
+    if (deleted.isErr()) return err("DB_ERROR");
+
+    return ok(undefined);
+  }
+}

--- a/apps/api/src/feature/auth/register/repository.ts
+++ b/apps/api/src/feature/auth/register/repository.ts
@@ -1,0 +1,47 @@
+import { prisma } from "@repo/database";
+import { ResultAsync } from "neverthrow";
+import type { DbError } from "../../../shared/db-error";
+
+export type RegisteredUser = {
+  id: string;
+  email: string;
+  name: string | null;
+};
+
+export type CreateUserData = {
+  email: string;
+  passwordHash: string;
+  name?: string;
+};
+
+export interface RegisterRepository {
+  findByEmail(email: string): ResultAsync<{ id: string } | null, DbError>;
+  create(data: CreateUserData): ResultAsync<RegisteredUser, DbError>;
+}
+
+export class PrismaRegisterRepository implements RegisterRepository {
+  findByEmail(email: string): ResultAsync<{ id: string } | null, DbError> {
+    return ResultAsync.fromPromise(
+      prisma.user.findUnique({ where: { email }, select: { id: true } }),
+      (cause): DbError => ({ type: "DB_ERROR", cause }),
+    );
+  }
+
+  create(data: CreateUserData): ResultAsync<RegisteredUser, DbError> {
+    return ResultAsync.fromPromise(
+      prisma.user.create({
+        data: {
+          email: data.email,
+          password: data.passwordHash,
+          name: data.name,
+        },
+        select: { id: true, email: true, name: true },
+      }),
+      (cause): DbError => ({ type: "DB_ERROR", cause }),
+    ).map((user) => ({
+      id: user.id,
+      email: user.email ?? data.email,
+      name: user.name,
+    }));
+  }
+}

--- a/apps/api/src/feature/auth/register/router.ts
+++ b/apps/api/src/feature/auth/register/router.ts
@@ -1,0 +1,31 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { match } from "ts-pattern";
+import type { SessionEnv } from "../../../shared/session-middleware/types";
+import { PrismaRegisterRepository } from "./repository";
+import { RegisterRoute } from "./schema";
+import { RegisterUseCase } from "./usecase";
+
+export const registerRouter = () => {
+  const app = new OpenAPIHono<SessionEnv>();
+
+  const usecase = new RegisterUseCase(new PrismaRegisterRepository());
+
+  app.openapi(RegisterRoute, async (c) => {
+    const input = c.req.valid("json");
+
+    const result = await usecase.execute(input);
+
+    return result.match(
+      (user) => c.json({ id: user.id, email: user.email, name: user.name }, 201),
+      (error) =>
+        match(error)
+          .with("EMAIL_TAKEN", () =>
+            c.json({ error: "このメールアドレスは既に登録されています" }, 409),
+          )
+          .with("DB_ERROR", () => c.json({ error: "登録に失敗しました" }, 500))
+          .exhaustive(),
+    );
+  });
+
+  return app;
+};

--- a/apps/api/src/feature/auth/register/schema.ts
+++ b/apps/api/src/feature/auth/register/schema.ts
@@ -1,0 +1,46 @@
+import { createRoute, z } from "@hono/zod-openapi";
+
+export const RegisterRequest = z
+  .object({
+    email: z.string().email({ message: "正しいメールアドレスを入力してください" }),
+    password: z.string().min(8, { message: "パスワードは8文字以上にしてください" }),
+    name: z.string().optional(),
+  })
+  .openapi("RegisterRequest");
+
+export const RegisterResponse = z
+  .object({
+    id: z.string(),
+    email: z.string(),
+    name: z.string().nullable(),
+  })
+  .openapi("RegisterResponse");
+
+export const RegisterErrorResponse = z
+  .object({ error: z.string() })
+  .openapi("RegisterErrorResponse");
+
+export const RegisterRoute = createRoute({
+  method: "post",
+  path: "/auth/register",
+  description: "ユーザー登録 (メール + パスワード)",
+  request: {
+    body: {
+      content: { "application/json": { schema: RegisterRequest } },
+    },
+  },
+  responses: {
+    201: {
+      content: { "application/json": { schema: RegisterResponse } },
+      description: "登録成功",
+    },
+    409: {
+      content: { "application/json": { schema: RegisterErrorResponse } },
+      description: "メールアドレス重複",
+    },
+    500: {
+      content: { "application/json": { schema: RegisterErrorResponse } },
+      description: "サーバーエラー",
+    },
+  },
+});

--- a/apps/api/src/feature/auth/register/usecase.ts
+++ b/apps/api/src/feature/auth/register/usecase.ts
@@ -1,0 +1,36 @@
+import bcrypt from "bcryptjs";
+import { err, ok, type Result } from "neverthrow";
+import type { RegisteredUser, RegisterRepository } from "./repository";
+
+const BCRYPT_ROUNDS = 10;
+
+export type RegisterInput = {
+  email: string;
+  password: string;
+  name?: string;
+};
+
+export type RegisterError = "EMAIL_TAKEN" | "DB_ERROR";
+
+export class RegisterUseCase {
+  constructor(private readonly repo: RegisterRepository) {}
+
+  async execute(
+    input: RegisterInput,
+  ): Promise<Result<RegisteredUser, RegisterError>> {
+    const existing = await this.repo.findByEmail(input.email);
+    if (existing.isErr()) return err("DB_ERROR");
+    if (existing.value) return err("EMAIL_TAKEN");
+
+    const passwordHash = await bcrypt.hash(input.password, BCRYPT_ROUNDS);
+
+    const created = await this.repo.create({
+      email: input.email,
+      passwordHash,
+      name: input.name,
+    });
+    if (created.isErr()) return err("DB_ERROR");
+
+    return ok(created.value);
+  }
+}

--- a/apps/api/src/feature/note/create/router.ts
+++ b/apps/api/src/feature/note/create/router.ts
@@ -1,19 +1,30 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { match } from "ts-pattern";
+import type { SessionEnv } from "../../../shared/session-middleware/types";
 import { PrismaCreateNoteRepository } from "./repository";
 import { CreateNoteRoute } from "./schema";
 import { CreateNoteUseCase } from "./usecase";
 
 export const createNoteRouter = () => {
-  const app = new OpenAPIHono();
+  const app = new OpenAPIHono<SessionEnv>();
 
   // 手動DI: Repository を生成して UseCase に注入する
   const usecase = new CreateNoteUseCase(new PrismaCreateNoteRepository());
 
   app.openapi(CreateNoteRoute, async (c) => {
+    // セッション必須: 未ログインなら 401
+    const session = c.get("session");
+    if (!session) {
+      return c.json({ error: "ログインが必要です" }, 401);
+    }
+
     const input = c.req.valid("json");
 
-    const result = await usecase.execute(input);
+    const result = await usecase.execute({
+      title: input.title,
+      content: input.content,
+      userId: session.userId,
+    });
 
     return result.match(
       (note) =>

--- a/apps/api/src/feature/note/create/schema.ts
+++ b/apps/api/src/feature/note/create/schema.ts
@@ -25,7 +25,8 @@ export const CreateNoteErrorResponse = z
 export const CreateNoteRoute = createRoute({
   method: "post",
   path: "/notes",
-  description: "ノートを1件作成する",
+  description: "ノートを1件作成する (要ログイン)",
+  security: [{ sessionCookie: [] }],
   request: {
     body: {
       content: {
@@ -43,6 +44,14 @@ export const CreateNoteRoute = createRoute({
         },
       },
       description: "作成成功",
+    },
+    401: {
+      content: {
+        "application/json": {
+          schema: CreateNoteErrorResponse,
+        },
+      },
+      description: "未ログイン",
     },
     500: {
       content: {

--- a/apps/api/src/feature/note/create/usecase.ts
+++ b/apps/api/src/feature/note/create/usecase.ts
@@ -1,14 +1,10 @@
 import type { Result } from "neverthrow";
 import type { CreatedNote, CreateNoteRepository } from "./repository";
 
-// 案A: 認証を実装するまでは固定のダミーユーザーIDを使う。
-// DBを再接続したら、このIDの User 行が存在する必要がある(FK制約)。
-// 認証の縦切りを追加したら、セッションから取得した本物のIDに差し替える。
-const DUMMY_USER_ID = "dummy-user-id";
-
 export type CreateNoteInput = {
   title: string;
   content: string;
+  userId: string;
 };
 
 export type CreateNoteError = "DB_ERROR";
@@ -24,7 +20,7 @@ export class CreateNoteUseCase {
       .create({
         title: input.title,
         content: input.content,
-        userId: DUMMY_USER_ID,
+        userId: input.userId,
       })
       .mapErr((): CreateNoteError => "DB_ERROR");
   }

--- a/apps/api/src/shared/session-middleware/middleware.ts
+++ b/apps/api/src/shared/session-middleware/middleware.ts
@@ -1,0 +1,20 @@
+import { getCookie } from "hono/cookie";
+import { createMiddleware } from "hono/factory";
+import { findSessionByToken } from "./repository";
+import { SESSION_COOKIE_NAME, type SessionEnv } from "./types";
+
+// 毎リクエストで Cookie を読み、有効なセッションがあれば c.var.session に載せる。
+// 認証必須かどうかは各ルーター側で session の有無を見て判断する。
+export const sessionMiddleware = createMiddleware<SessionEnv>(async (c, next) => {
+  const token = getCookie(c, SESSION_COOKIE_NAME);
+
+  if (!token) {
+    c.set("session", null);
+    await next();
+    return;
+  }
+
+  const result = await findSessionByToken(token);
+  c.set("session", result.isOk() ? result.value : null);
+  await next();
+});

--- a/apps/api/src/shared/session-middleware/repository.ts
+++ b/apps/api/src/shared/session-middleware/repository.ts
@@ -1,0 +1,22 @@
+import { prisma } from "@repo/database";
+import { ResultAsync } from "neverthrow";
+import type { DbError } from "../db-error";
+import type { AuthSession } from "./types";
+
+// Cookie のトークンから有効なセッションを引く。期限切れ・未存在は null。
+export const findSessionByToken = (
+  sessionToken: string,
+): ResultAsync<AuthSession | null, DbError> => {
+  return ResultAsync.fromPromise(
+    prisma.session.findUnique({ where: { sessionToken } }),
+    (cause): DbError => ({ type: "DB_ERROR", cause }),
+  ).map((session) => {
+    if (!session) return null;
+    if (session.expires < new Date()) return null;
+    return {
+      userId: session.userId,
+      sessionToken: session.sessionToken,
+      expiresAt: session.expires,
+    };
+  });
+};

--- a/apps/api/src/shared/session-middleware/types.ts
+++ b/apps/api/src/shared/session-middleware/types.ts
@@ -1,0 +1,17 @@
+export const SESSION_COOKIE_NAME = "session_token";
+
+// セッションの有効期間 (日)
+export const SESSION_DURATION_DAYS = 30;
+
+export type AuthSession = {
+  userId: string;
+  sessionToken: string;
+  expiresAt: Date;
+};
+
+// Hono のコンテキストに載せる型。middleware が c.set("session", ...) する。
+export type SessionEnv = {
+  Variables: {
+    session: AuthSession | null;
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
+      bcryptjs:
+        specifier: ^3.0.3
+        version: 3.0.3
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
@@ -1825,6 +1828,10 @@ packages:
   bcrypt@6.0.0:
     resolution: {integrity: sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==}
     engines: {node: '>= 18'}
+
+  bcryptjs@3.0.3:
+    resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
+    hasBin: true
 
   better-result@2.9.2:
     resolution: {integrity: sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q==}
@@ -5464,6 +5471,8 @@ snapshots:
     dependencies:
       node-addon-api: 8.8.0
       node-gyp-build: 4.8.4
+
+  bcryptjs@3.0.3: {}
 
   better-result@2.9.2: {}
 


### PR DESCRIPTION
## Summary
- `apps/api` に自前セッション認証を実装（NextAuth を段階的に置き換える第一歩）
- `shared/session-middleware`: Cookie (`session_token`) を検証し、セッションを `c.var.session` に載せる
- `POST /auth/register`: bcryptjs でハッシュ化して User 作成
- `POST /auth/login`: パスワード照合後に httpOnly クッキーを発行
- `POST /auth/logout`: セッション削除 + クッキー破棄
- create-note を**ログイン必須**化し、ダミー userId をセッションの userId に置換
- 既存の `User`/`Session` スキーマを再利用（マイグレーション不要）

## 動作確認
- [x] 3パッケージとも型チェック通過 (`pnpm -r check:type`)
- [x] `POST /notes`（未ログイン）→ 401（DB非依存で即拒否）
- [x] `POST /auth/register` / `login` バリデーション → 400
- [x] `POST /auth/logout` → 200（Cookie破棄）
- [ ] login→Cookie→認証付きノート作成の通し疎通 → DB再接続後（phase C）に確認

## 既知のTODO（このPRの範囲外）
- DB再接続（Supabase再作成 + Prisma 7 driver adapter）で register/login の正常系を検証
- `apps/web` の旧 NextAuth ルートは役割が重複 → web を api 認証に繋ぐ段階で削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)