### PR TITLE
build: api を Cloud Run 用にコンテナ化 (Dockerfile)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+**/node_modules
+**/dist
+**/.next
+**/.turbo
+.git
+.env
+.env.*
+!.env.example
+**/*.tsbuildinfo
+*.log

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+# ビルドコンテキストはリポジトリルート想定:
+#   docker build -f apps/api/Dockerfile -t note-api .
+
+FROM node:22-slim AS builder
+RUN corepack enable && \
+    apt-get update -y && apt-get install -y --no-install-recommends openssl && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+
+# 依存解決に必要なファイルを先にコピー (レイヤキャッシュを効かせる)
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json turbo.json ./
+COPY apps/api/package.json apps/api/package.json
+COPY packages/database/package.json packages/database/package.json
+# postinstall(prisma generate)に schema/config が必要
+COPY packages/database/prisma packages/database/prisma
+COPY packages/database/prisma.config.ts packages/database/prisma.config.ts
+
+# api とその依存(database)だけインストール
+RUN pnpm install --frozen-lockfile --filter api...
+
+# ソースをコピーしてビルド
+COPY packages/database packages/database
+COPY apps/api apps/api
+RUN pnpm --filter api build
+
+# ---- 実行ステージ ----
+FROM node:22-slim AS runner
+RUN apt-get update -y && apt-get install -y --no-install-recommends openssl && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+ENV NODE_ENV=production
+
+# pnpm のシンボリックリンク構造を保つため、まるごとコピーする
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/apps/api/node_modules ./apps/api/node_modules
+COPY --from=builder /app/packages ./packages
+COPY --from=builder /app/apps/api/dist ./apps/api/dist
+COPY --from=builder /app/apps/api/package.json ./apps/api/package.json
+
+# Cloud Run は PORT 環境変数を注入する (既定 8080)。index.ts が参照する。
+EXPOSE 8080
+CMD ["node", "apps/api/dist/index.js"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,11 +12,14 @@
   "dependencies": {
     "@hono/node-server": "^1.12.0",
     "@hono/zod-openapi": "^0.15.0",
+    "@prisma/adapter-pg": "^7.2.0",
+    "@prisma/client": "^7.2.0",
     "@repo/database": "workspace:*",
     "bcryptjs": "^3.0.3",
     "dotenv": "^16.4.5",
     "hono": "^4.5.1",
     "neverthrow": "^8.1.1",
+    "pg": "^8.13.0",
     "ts-pattern": "^5.2.0",
     "zod": "^3.23.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@hono/zod-openapi':
         specifier: ^0.15.0
         version: 0.15.3(hono@4.12.23)(zod@3.25.76)
+      '@prisma/adapter-pg':
+        specifier: ^7.2.0
+        version: 7.8.0
+      '@prisma/client':
+        specifier: ^7.2.0
+        version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3))(typescript@5.9.3)
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
@@ -35,6 +41,9 @@ importers:
       neverthrow:
         specifier: ^8.1.1
         version: 8.2.0
+      pg:
+        specifier: ^8.13.0
+        version: 8.21.0
       ts-pattern:
         specifier: ^5.2.0
         version: 5.9.0


### PR DESCRIPTION
## Summary
- `apps/api/Dockerfile` を追加（Cloud Run 用）。pnpm モノレポ対応の2ステージビルド（`prisma generate` → `tsup` → `node dist/index.js`）
- tsup が `@repo/database` をバンドルする都合で、実行時依存（`@prisma/client` / `@prisma/adapter-pg` / `pg`）を `apps/api` 側にも明示
- `.dockerignore` 追加

## 動作確認（ローカル Docker）
- [x] イメージビルド成功
- [x] `GET /health` → 200
- [x] `POST /auth/register`（コンテナ → ホスト Postgres `host.docker.internal:5433`）→ 201（コンテナからの実DB接続を確認）

## スコープ
- このPRは**コンテナ化（Dockerfile）まで**。実際の `gcloud run deploy`（GCP プロジェクト作成・Artifact Registry・環境変数設定）は別途オペレーション作業
- 本番ランタイムの `DATABASE_URL` は Supabase の Transaction pooler（6543）を Cloud Run の環境変数に設定する想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)