### PR TITLE
feat: ノート一覧・削除 + web ノート画面 (Phase 2)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,6 +5,8 @@ import { logoutRouter } from "./feature/auth/logout/router";
 import { meRouter } from "./feature/auth/me/router";
 import { registerRouter } from "./feature/auth/register/router";
 import { createNoteRouter } from "./feature/note/create/router";
+import { deleteNoteRouter } from "./feature/note/delete/router";
+import { listNotesRouter } from "./feature/note/list/router";
 import { sessionMiddleware } from "./shared/session-middleware/middleware";
 import type { SessionEnv } from "./shared/session-middleware/types";
 
@@ -33,6 +35,8 @@ app.route("/", meRouter());
 
 // ノート
 app.route("/", createNoteRouter());
+app.route("/", listNotesRouter());
+app.route("/", deleteNoteRouter());
 
 app.openAPIRegistry.registerComponent("securitySchemes", "sessionCookie", {
   type: "apiKey",

--- a/apps/api/src/feature/note/delete/repository.ts
+++ b/apps/api/src/feature/note/delete/repository.ts
@@ -1,0 +1,17 @@
+import { prisma } from "@repo/database";
+import { ResultAsync } from "neverthrow";
+import type { DbError } from "../../../shared/db-error";
+
+export interface DeleteNoteRepository {
+  // 自分(userId)のノートのみ削除。削除件数を返す(0なら対象なし)。
+  deleteForUser(id: string, userId: string): ResultAsync<number, DbError>;
+}
+
+export class PrismaDeleteNoteRepository implements DeleteNoteRepository {
+  deleteForUser(id: string, userId: string): ResultAsync<number, DbError> {
+    return ResultAsync.fromPromise(
+      prisma.note.deleteMany({ where: { id, userId } }),
+      (cause): DbError => ({ type: "DB_ERROR", cause }),
+    ).map((r) => r.count);
+  }
+}

--- a/apps/api/src/feature/note/delete/router.ts
+++ b/apps/api/src/feature/note/delete/router.ts
@@ -1,0 +1,31 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import type { SessionEnv } from "../../../shared/session-middleware/types";
+import { PrismaDeleteNoteRepository } from "./repository";
+import { DeleteNoteRoute } from "./schema";
+
+export const deleteNoteRouter = () => {
+  const app = new OpenAPIHono<SessionEnv>();
+
+  const repo = new PrismaDeleteNoteRepository();
+
+  app.openapi(DeleteNoteRoute, async (c) => {
+    const session = c.get("session");
+    if (!session) {
+      return c.json({ error: "ログインが必要です" }, 401);
+    }
+
+    const { id } = c.req.valid("param");
+
+    const result = await repo.deleteForUser(id, session.userId);
+
+    return result.match(
+      (count) =>
+        count > 0
+          ? c.json({ message: "削除しました" }, 200)
+          : c.json({ error: "ノートが見つかりません" }, 404),
+      () => c.json({ error: "削除に失敗しました" }, 500),
+    );
+  });
+
+  return app;
+};

--- a/apps/api/src/feature/note/delete/schema.ts
+++ b/apps/api/src/feature/note/delete/schema.ts
@@ -1,0 +1,37 @@
+import { createRoute, z } from "@hono/zod-openapi";
+
+export const DeleteNoteResponse = z
+  .object({ message: z.string() })
+  .openapi("DeleteNoteResponse");
+
+export const DeleteNoteErrorResponse = z
+  .object({ error: z.string() })
+  .openapi("DeleteNoteErrorResponse");
+
+export const DeleteNoteRoute = createRoute({
+  method: "delete",
+  path: "/notes/{id}",
+  description: "ノートを削除する (自分のノートのみ, 要ログイン)",
+  security: [{ sessionCookie: [] }],
+  request: {
+    params: z.object({ id: z.string() }),
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: DeleteNoteResponse } },
+      description: "削除成功",
+    },
+    401: {
+      content: { "application/json": { schema: DeleteNoteErrorResponse } },
+      description: "未ログイン",
+    },
+    404: {
+      content: { "application/json": { schema: DeleteNoteErrorResponse } },
+      description: "対象が無い / 自分のノートでない",
+    },
+    500: {
+      content: { "application/json": { schema: DeleteNoteErrorResponse } },
+      description: "サーバーエラー",
+    },
+  },
+});

--- a/apps/api/src/feature/note/list/repository.ts
+++ b/apps/api/src/feature/note/list/repository.ts
@@ -1,0 +1,27 @@
+import { prisma } from "@repo/database";
+import { ResultAsync } from "neverthrow";
+import type { DbError } from "../../../shared/db-error";
+
+export type NoteListItem = {
+  id: string;
+  title: string;
+  content: string;
+  createdAt: Date;
+};
+
+export interface ListNotesRepository {
+  findByUserId(userId: string): ResultAsync<NoteListItem[], DbError>;
+}
+
+export class PrismaListNotesRepository implements ListNotesRepository {
+  findByUserId(userId: string): ResultAsync<NoteListItem[], DbError> {
+    return ResultAsync.fromPromise(
+      prisma.note.findMany({
+        where: { userId },
+        orderBy: { createdAt: "desc" },
+        select: { id: true, title: true, content: true, createdAt: true },
+      }),
+      (cause): DbError => ({ type: "DB_ERROR", cause }),
+    );
+  }
+}

--- a/apps/api/src/feature/note/list/router.ts
+++ b/apps/api/src/feature/note/list/router.ts
@@ -1,0 +1,35 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import type { SessionEnv } from "../../../shared/session-middleware/types";
+import { PrismaListNotesRepository } from "./repository";
+import { ListNotesRoute } from "./schema";
+
+export const listNotesRouter = () => {
+  const app = new OpenAPIHono<SessionEnv>();
+
+  const repo = new PrismaListNotesRepository();
+
+  app.openapi(ListNotesRoute, async (c) => {
+    const session = c.get("session");
+    if (!session) {
+      return c.json({ error: "ログインが必要です" }, 401);
+    }
+
+    const result = await repo.findByUserId(session.userId);
+
+    return result.match(
+      (notes) =>
+        c.json(
+          notes.map((n) => ({
+            id: n.id,
+            title: n.title,
+            content: n.content,
+            createdAt: n.createdAt.toISOString(),
+          })),
+          200,
+        ),
+      () => c.json({ error: "ノートの取得に失敗しました" }, 500),
+    );
+  });
+
+  return app;
+};

--- a/apps/api/src/feature/note/list/schema.ts
+++ b/apps/api/src/feature/note/list/schema.ts
@@ -1,0 +1,37 @@
+import { createRoute, z } from "@hono/zod-openapi";
+
+export const NoteItem = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+    content: z.string(),
+    createdAt: z.string(),
+  })
+  .openapi("NoteItem");
+
+export const ListNotesResponse = z.array(NoteItem).openapi("ListNotesResponse");
+
+export const ListNotesErrorResponse = z
+  .object({ error: z.string() })
+  .openapi("ListNotesErrorResponse");
+
+export const ListNotesRoute = createRoute({
+  method: "get",
+  path: "/notes",
+  description: "ログインユーザーのノート一覧 (要ログイン)",
+  security: [{ sessionCookie: [] }],
+  responses: {
+    200: {
+      content: { "application/json": { schema: ListNotesResponse } },
+      description: "一覧",
+    },
+    401: {
+      content: { "application/json": { schema: ListNotesErrorResponse } },
+      description: "未ログイン",
+    },
+    500: {
+      content: { "application/json": { schema: ListNotesErrorResponse } },
+      description: "サーバーエラー",
+    },
+  },
+});

--- a/apps/web/src/app/notes/page.tsx
+++ b/apps/web/src/app/notes/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { apiFetch } from "@/lib/api";
 
 type Note = {
@@ -20,22 +20,33 @@ export default function NotesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
-  const load = useCallback(async () => {
+  // 初回ロード (未ログインは /login へ誘導)
+  useEffect(() => {
+    let ignore = false;
+    (async () => {
+      const res = await apiFetch("/notes");
+      if (res.status === 401) {
+        router.push("/login");
+        return;
+      }
+      if (!ignore && res.ok) {
+        setNotes((await res.json()) as Note[]);
+      }
+      if (!ignore) {
+        setLoading(false);
+      }
+    })();
+    return () => {
+      ignore = true;
+    };
+  }, [router]);
+
+  async function refresh() {
     const res = await apiFetch("/notes");
-    // 未ログインはログイン画面へ (認証ガード)
-    if (res.status === 401) {
-      router.push("/login");
-      return;
-    }
     if (res.ok) {
       setNotes((await res.json()) as Note[]);
     }
-    setLoading(false);
-  }, [router]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+  }
 
   async function onCreate(e: React.FormEvent) {
     e.preventDefault();
@@ -47,7 +58,7 @@ export default function NotesPage() {
     if (res.ok) {
       setTitle("");
       setContent("");
-      await load();
+      await refresh();
       return;
     }
     const data = await res.json().catch(() => ({}));
@@ -56,7 +67,9 @@ export default function NotesPage() {
 
   async function onDelete(id: string) {
     const res = await apiFetch(`/notes/${id}`, { method: "DELETE" });
-    if (res.ok) await load();
+    if (res.ok) {
+      await refresh();
+    }
   }
 
   if (loading) {

--- a/apps/web/src/app/notes/page.tsx
+++ b/apps/web/src/app/notes/page.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { apiFetch } from "@/lib/api";
+
+type Note = {
+  id: string;
+  title: string;
+  content: string;
+  createdAt: string;
+};
+
+export default function NotesPage() {
+  const router = useRouter();
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const load = useCallback(async () => {
+    const res = await apiFetch("/notes");
+    // 未ログインはログイン画面へ (認証ガード)
+    if (res.status === 401) {
+      router.push("/login");
+      return;
+    }
+    if (res.ok) {
+      setNotes((await res.json()) as Note[]);
+    }
+    setLoading(false);
+  }, [router]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function onCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    const res = await apiFetch("/notes", {
+      method: "POST",
+      body: JSON.stringify({ title, content }),
+    });
+    if (res.ok) {
+      setTitle("");
+      setContent("");
+      await load();
+      return;
+    }
+    const data = await res.json().catch(() => ({}));
+    setError(data.error ?? "作成に失敗しました");
+  }
+
+  async function onDelete(id: string) {
+    const res = await apiFetch(`/notes/${id}`, { method: "DELETE" });
+    if (res.ok) await load();
+  }
+
+  if (loading) {
+    return <main className="p-8">読み込み中...</main>;
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl p-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">ノート</h1>
+        <Link href="/" className="text-sm underline">
+          ホーム
+        </Link>
+      </div>
+
+      <form onSubmit={onCreate} className="mb-8 flex flex-col gap-2">
+        <input
+          required
+          placeholder="タイトル"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="rounded border px-3 py-2"
+        />
+        <textarea
+          placeholder="本文"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          className="min-h-24 rounded border px-3 py-2"
+        />
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <button
+          type="submit"
+          className="self-start rounded bg-black px-4 py-2 text-white"
+        >
+          作成
+        </button>
+      </form>
+
+      <ul className="flex flex-col gap-3">
+        {notes.length === 0 && (
+          <li className="text-sm text-gray-500">ノートがありません</li>
+        )}
+        {notes.map((n) => (
+          <li key={n.id} className="rounded border p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <h2 className="font-bold">{n.title}</h2>
+                <p className="whitespace-pre-wrap break-words text-sm">
+                  {n.content}
+                </p>
+                <p className="mt-1 text-xs text-gray-400">
+                  {new Date(n.createdAt).toLocaleString()}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => onDelete(n.id)}
+                className="shrink-0 rounded border px-2 py-1 text-sm"
+              >
+                削除
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/web/src/components/auth-status.tsx
+++ b/apps/web/src/components/auth-status.tsx
@@ -33,6 +33,9 @@ export default function AuthStatus() {
   if (me) {
     return (
       <div className="flex items-center gap-3 text-sm">
+        <Link href="/notes" className="underline">
+          ノート
+        </Link>
         <span>{me.name ?? me.email} でログイン中</span>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- **api**: `GET /notes`（ログインユーザーのノート一覧, 新しい順）/ `DELETE /notes/{id}`（自分のノートのみ削除）を追加。いずれも要ログイン（未ログインは 401）
- **web**: `/notes` 画面を追加 — ノートの**一覧 + 作成 + 削除**、未ログイン時は `/login` へ誘導（認証ガード）
- `AuthStatus` にノートへの導線を追加

## 動作確認（ローカル, web `/bff` 経由）
- [x] 3パッケージとも型チェック通過
- [x] 作成×2 → `GET /notes` 200（2件, 新しい順）
- [x] `DELETE /notes/{id}` 200 → 再取得で 1件
- [x] 未ログインで `GET /notes` → 401
- 注: 画面のブラウザ操作は未確認（API 連携は curl で実証）

## スコープ
- 作成 UI はシンプルなフォーム（title + 本文）。BlockNote エディタとの連携（リッチ編集）は将来の磨き込み
- ノートの編集（更新）/単体取得は未実装（必要なら次フェーズ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)