### PR TITLE
feat: ノート更新機能を追加 (CRUD完成)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,6 +7,7 @@ import { registerRouter } from "./feature/auth/register/router";
 import { createNoteRouter } from "./feature/note/create/router";
 import { deleteNoteRouter } from "./feature/note/delete/router";
 import { listNotesRouter } from "./feature/note/list/router";
+import { updateNoteRouter } from "./feature/note/update/router";
 import { sessionMiddleware } from "./shared/session-middleware/middleware";
 import type { SessionEnv } from "./shared/session-middleware/types";
 
@@ -36,6 +37,7 @@ app.route("/", meRouter());
 // ノート
 app.route("/", createNoteRouter());
 app.route("/", listNotesRouter());
+app.route("/", updateNoteRouter());
 app.route("/", deleteNoteRouter());
 
 app.openAPIRegistry.registerComponent("securitySchemes", "sessionCookie", {

--- a/apps/api/src/feature/note/update/repository.ts
+++ b/apps/api/src/feature/note/update/repository.ts
@@ -1,0 +1,53 @@
+import { prisma } from "@repo/database";
+import { okAsync, ResultAsync } from "neverthrow";
+import type { DbError } from "../../../shared/db-error";
+
+export type UpdatedNote = {
+  id: string;
+  title: string;
+  content: string;
+  createdAt: Date;
+};
+
+export type UpdateNoteData = {
+  title: string;
+  content: string;
+};
+
+export interface UpdateNoteRepository {
+  // 自分(userId)のノートのみ更新。対象が無ければ null。
+  updateForUser(
+    id: string,
+    userId: string,
+    data: UpdateNoteData,
+  ): ResultAsync<UpdatedNote | null, DbError>;
+}
+
+const toDbError = (cause: unknown): DbError => ({ type: "DB_ERROR", cause });
+
+export class PrismaUpdateNoteRepository implements UpdateNoteRepository {
+  updateForUser(
+    id: string,
+    userId: string,
+    data: UpdateNoteData,
+  ): ResultAsync<UpdatedNote | null, DbError> {
+    // updateMany で所有者(userId)を条件に含めて他人のノートは更新させない
+    return ResultAsync.fromPromise(
+      prisma.note.updateMany({
+        where: { id, userId },
+        data: { title: data.title, content: data.content },
+      }),
+      toDbError,
+    ).andThen((res) =>
+      res.count === 0
+        ? okAsync<UpdatedNote | null, DbError>(null)
+        : ResultAsync.fromPromise(
+            prisma.note.findUnique({
+              where: { id },
+              select: { id: true, title: true, content: true, createdAt: true },
+            }),
+            toDbError,
+          ),
+    );
+  }
+}

--- a/apps/api/src/feature/note/update/router.ts
+++ b/apps/api/src/feature/note/update/router.ts
@@ -1,0 +1,40 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import type { SessionEnv } from "../../../shared/session-middleware/types";
+import { PrismaUpdateNoteRepository } from "./repository";
+import { UpdateNoteRoute } from "./schema";
+
+export const updateNoteRouter = () => {
+  const app = new OpenAPIHono<SessionEnv>();
+
+  const repo = new PrismaUpdateNoteRepository();
+
+  app.openapi(UpdateNoteRoute, async (c) => {
+    const session = c.get("session");
+    if (!session) {
+      return c.json({ error: "ログインが必要です" }, 401);
+    }
+
+    const { id } = c.req.valid("param");
+    const input = c.req.valid("json");
+
+    const result = await repo.updateForUser(id, session.userId, input);
+
+    return result.match(
+      (note) =>
+        note
+          ? c.json(
+              {
+                id: note.id,
+                title: note.title,
+                content: note.content,
+                createdAt: note.createdAt.toISOString(),
+              },
+              200,
+            )
+          : c.json({ error: "ノートが見つかりません" }, 404),
+      () => c.json({ error: "更新に失敗しました" }, 500),
+    );
+  });
+
+  return app;
+};

--- a/apps/api/src/feature/note/update/schema.ts
+++ b/apps/api/src/feature/note/update/schema.ts
@@ -1,0 +1,52 @@
+import { createRoute, z } from "@hono/zod-openapi";
+
+export const UpdateNoteRequest = z
+  .object({
+    title: z.string().min(1, { message: "タイトルは必須です" }),
+    content: z.string(),
+  })
+  .openapi("UpdateNoteRequest");
+
+export const UpdateNoteResponse = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+    content: z.string(),
+    createdAt: z.string(),
+  })
+  .openapi("UpdateNoteResponse");
+
+export const UpdateNoteErrorResponse = z
+  .object({ error: z.string() })
+  .openapi("UpdateNoteErrorResponse");
+
+export const UpdateNoteRoute = createRoute({
+  method: "put",
+  path: "/notes/{id}",
+  description: "ノートを更新する (自分のノートのみ, 要ログイン)",
+  security: [{ sessionCookie: [] }],
+  request: {
+    params: z.object({ id: z.string() }),
+    body: {
+      content: { "application/json": { schema: UpdateNoteRequest } },
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: UpdateNoteResponse } },
+      description: "更新成功",
+    },
+    401: {
+      content: { "application/json": { schema: UpdateNoteErrorResponse } },
+      description: "未ログイン",
+    },
+    404: {
+      content: { "application/json": { schema: UpdateNoteErrorResponse } },
+      description: "対象が無い / 自分のノートでない",
+    },
+    500: {
+      content: { "application/json": { schema: UpdateNoteErrorResponse } },
+      description: "サーバーエラー",
+    },
+  },
+});

--- a/apps/web/src/app/notes/page.tsx
+++ b/apps/web/src/app/notes/page.tsx
@@ -20,6 +20,11 @@ export default function NotesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
+  // 編集中のノート
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState("");
+  const [editContent, setEditContent] = useState("");
+
   // 初回ロード (未ログインは /login へ誘導)
   useEffect(() => {
     let ignore = false;
@@ -72,6 +77,27 @@ export default function NotesPage() {
     }
   }
 
+  function startEdit(n: Note) {
+    setEditingId(n.id);
+    setEditTitle(n.title);
+    setEditContent(n.content);
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+  }
+
+  async function onUpdate(id: string) {
+    const res = await apiFetch(`/notes/${id}`, {
+      method: "PUT",
+      body: JSON.stringify({ title: editTitle, content: editContent }),
+    });
+    if (res.ok) {
+      setEditingId(null);
+      await refresh();
+    }
+  }
+
   if (loading) {
     return <main className="p-8">読み込み中...</main>;
   }
@@ -114,24 +140,64 @@ export default function NotesPage() {
         )}
         {notes.map((n) => (
           <li key={n.id} className="rounded border p-3">
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <h2 className="font-bold">{n.title}</h2>
-                <p className="whitespace-pre-wrap break-words text-sm">
-                  {n.content}
-                </p>
-                <p className="mt-1 text-xs text-gray-400">
-                  {new Date(n.createdAt).toLocaleString()}
-                </p>
+            {editingId === n.id ? (
+              <div className="flex flex-col gap-2">
+                <input
+                  value={editTitle}
+                  onChange={(e) => setEditTitle(e.target.value)}
+                  className="rounded border px-3 py-2"
+                />
+                <textarea
+                  value={editContent}
+                  onChange={(e) => setEditContent(e.target.value)}
+                  className="min-h-24 rounded border px-3 py-2"
+                />
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onUpdate(n.id)}
+                    className="rounded bg-black px-3 py-1 text-sm text-white"
+                  >
+                    保存
+                  </button>
+                  <button
+                    type="button"
+                    onClick={cancelEdit}
+                    className="rounded border px-3 py-1 text-sm"
+                  >
+                    キャンセル
+                  </button>
+                </div>
               </div>
-              <button
-                type="button"
-                onClick={() => onDelete(n.id)}
-                className="shrink-0 rounded border px-2 py-1 text-sm"
-              >
-                削除
-              </button>
-            </div>
+            ) : (
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h2 className="font-bold">{n.title}</h2>
+                  <p className="whitespace-pre-wrap break-words text-sm">
+                    {n.content}
+                  </p>
+                  <p className="mt-1 text-xs text-gray-400">
+                    {new Date(n.createdAt).toLocaleString()}
+                  </p>
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <button
+                    type="button"
+                    onClick={() => startEdit(n)}
+                    className="rounded border px-2 py-1 text-sm"
+                  >
+                    編集
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDelete(n.id)}
+                    className="rounded border px-2 py-1 text-sm"
+                  >
+                    削除
+                  </button>
+                </div>
+              </div>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- **api**: `PUT /notes/{id}`（自分のノートのみ更新, 要ログイン）を追加。これでノート CRUD（作成/一覧/更新/削除）が揃った
- **web**: `/notes` 画面に**インライン編集 UI**（編集 → タイトル/本文を書き換え → 保存/キャンセル）を追加

## 動作確認（ローカル, web `/bff` 経由）
- [x] lint / 3パッケージ型チェック 通過
- [x] 作成 → `PUT /notes/{id}` 200（更新後の値を返す）→ `GET /notes` に反映
- [x] 存在しない ID への PUT → 404
- 注: 画面のブラウザ操作は未確認（API 連携は curl で実証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)