### PR TITLE
fix: 本番の /bff 転送先デフォルトを Render の api に

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,8 +2,15 @@ import type { NextConfig } from "next";
 
 // ブラウザは web 自身の /bff/* を叩き、Next がそれを api に転送する(同一オリジン化)。
 // これにより別サイト間の Cookie 制限を回避し、api の Cookie 認証をそのまま使える。
-// API_URL: ローカルは既定の localhost:3080、本番(Vercel)では Render の URL を環境変数で指定。
-const apiUrl = process.env.API_URL ?? "http://localhost:3080";
+// 転送先の決定 (rewrite はビルド時に評価される):
+//   1. API_URL 環境変数があればそれを使う (上書き可能)
+//   2. 本番ビルドでは Render の api をデフォルトにする (Vercel の env 設定漏れでも動くように)
+//   3. それ以外(ローカル開発)は localhost:3080
+const apiUrl =
+  process.env.API_URL ??
+  (process.env.NODE_ENV === "production"
+    ? "https://note-app-hstp.onrender.com"
+    : "http://localhost:3080");
 
 const nextConfig: NextConfig = {
   async rewrites() {


### PR DESCRIPTION
## 背景
Vercel 本番で `/bff/*` が `localhost` を向き、`DNS_HOSTNAME_RESOLVED_PRIVATE` で 404 になっていた。原因は `next.config` の rewrite 先が**ビルド時**の `API_URL` を参照しているが、Vercel の env がビルドに反映されていなかったため（再デプロイのキャッシュ/スコープ問題）。

## 修正
`next.config.ts` の転送先決定を以下に:
1. `API_URL` があればそれ（上書き可能）
2. 本番ビルド（`NODE_ENV=production`）では **Render の api をデフォルト**
3. それ以外（ローカル開発）は `localhost:3080`

これで Vercel の env 設定に依存せず本番で api に繋がる。

## マージ後
- このPRをマージ → Vercel が本番を再ビルド → `/bff` が Render を向く
- マージ後に本番 URL で疎通確認します

🤖 Generated with [Claude Code](https://claude.com/claude-code)